### PR TITLE
Use updated ruff keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,21 @@ venv = ".venv"
 
 [tool.ruff]
 target-version = 'py38'
+
+exclude = [
+    "migrations",
+    "__pycache__",
+    "manage.py",
+    "settings.py",
+    "env",
+    ".env",
+    "venv",
+    ".venv",
+]
+
+line-length = 120  # Must agree with Black
+
+[tool.ruff.lint]
 select = [
     "B",  # flake8-bugbear
     "C4", # flake8-comprehensions
@@ -105,17 +120,6 @@ select = [
     "YTT", # flake8-2020
 ]
 
-exclude = [
-    "migrations",
-    "__pycache__",
-    "manage.py",
-    "settings.py",
-    "env",
-    ".env",
-    "venv",
-    ".venv",
-]
-
 ignore = [
     "B905",  # zip strict=True; remove once python <3.10 support is dropped.
     "D100",
@@ -133,19 +137,18 @@ ignore = [
     "F401",
     "TRY003",  # Avoid specifying messages outside exception class; overly strict, especially for ValueError
 ]
-line-length = 120  # Must agree with Black
 
-[tool.ruff.flake8-bugbear]
+[tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = [
     "chr",
     "typer.Argument",
     "typer.Option",
 ]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [
     "D100",
     "D101",
@@ -161,7 +164,7 @@ convention = "numpy"
     "PGH001",  # use of "eval"
 ]
 
-[tool.ruff.pep8-naming]
+[tool.ruff.lint.pep8-naming]
 staticmethod-decorators = [
     "pydantic.validator",
     "pydantic.root_validator",


### PR DESCRIPTION
At some point in the future, we'll be moving over to ruff's builtin `black` replacement, I would just like it to mature for a few more months. 